### PR TITLE
fix bug

### DIFF
--- a/myapp/__init__.py
+++ b/myapp/__init__.py
@@ -15,7 +15,7 @@ from flask_compress import Compress
 from flask_migrate import Migrate
 from flask_talisman import Talisman
 from flask_wtf.csrf import CSRFProtect
-from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.middleware.proxy_fix import ProxyFix
 import wtforms_json
 
 from myapp import config


### PR DESCRIPTION
Deprecated since version 0.15: werkzeug.contrib.fixers.ProxyFix has moved to werkzeug.middleware.proxy_fix. This import will be removed in 1.0