### PR TITLE
解决在使用cube的grafana对接自有Prometheus时部分panel无法显示的问题

### DIFF
--- a/install/kubernetes/all_image.py
+++ b/install/kubernetes/all_image.py
@@ -45,7 +45,7 @@ new_prometheus = [
     "quay.io/prometheus-operator/prometheus-operator:v0.46.0",
     'quay.io/prometheus-operator/prometheus-operator:v0.56.1',
     "k8s.gcr.io/prometheus-adapter/prometheus-adapter:v0.9.1",
-    'grafana/grafana:7.5.2'
+    'grafana/grafana:9.1.5'
 ]
 
 istio=[

--- a/install/kubernetes/prometheus/grafana/dashboard/pod-info.json
+++ b/install/kubernetes/prometheus/grafana/dashboard/pod-info.json
@@ -105,7 +105,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum by (node,namespace,pod) (rate(container_cpu_usage_seconds_total{job=\"kubelet\", image!=\"\",container_name!=\"POD\",pod!=\"\",namespace=~\"pipeline|jupyter|service|katib\"}[1m]))",
+          "expr": "sum by (node,namespace,pod) (rate(container_cpu_usage_seconds_total{job=\"kubelet\", image!=\"\",container_name!=\"POD\",pod!=\"\",namespace=~\"pipeline|jupyter|service|katib\"}[2m]))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -406,7 +406,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{job=\"kubelet\", image!=\"\",container_name!=\"POD\",pod=~\".*$pod.*\"}[1m]))",
+          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{job=\"kubelet\", image!=\"\",container_name!=\"POD\",pod=~\".*$pod.*\"}[2m]))",
           "format": "time_series",
           "instant": false,
           "interval": "30s",
@@ -718,7 +718,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (pod) (rate(container_network_receive_bytes_total{job=\"kubelet\", image!=\"\",container_name!=\"POD\",pod=~\".*$pod.*\"}[1m]))",
+          "expr": "sum by (pod) (rate(container_network_receive_bytes_total{job=\"kubelet\", image!=\"\",container_name!=\"POD\",pod=~\".*$pod.*\"}[2m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -727,7 +727,7 @@
         },
         {
           "exemplar": true,
-          "expr": "- sum by (pod) (rate(container_network_transmit_bytes_total{job=\"kubelet\", image!=\"\",container_name!=\"POD\",pod=~\".*$pod.*\"}[1m]))",
+          "expr": "- sum by (pod) (rate(container_network_transmit_bytes_total{job=\"kubelet\", image!=\"\",container_name!=\"POD\",pod=~\".*$pod.*\"}[2m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/install/kubernetes/prometheus/grafana/grafana-dp.yml
+++ b/install/kubernetes/prometheus/grafana/grafana-dp.yml
@@ -26,7 +26,7 @@ spec:
                 - "true"
       containers:
       - name: grafana
-        image:  grafana/grafana:7.5.2
+        image:  grafana/grafana:9.1.5
         env:
         - name: GRAFANA_PORT
           value: "3000"

--- a/install/kubernetes/pull_image_kubeflow.sh
+++ b/install/kubernetes/pull_image_kubeflow.sh
@@ -36,7 +36,7 @@ docker pull ccr.ccs.tencentyun.com/cube-studio/quay.io-prometheus-prometheus:v2.
 docker pull ccr.ccs.tencentyun.com/cube-studio/quay.io-prometheus-prometheus:v2.3.1 && docker tag ccr.ccs.tencentyun.com/cube-studio/quay.io-prometheus-prometheus:v2.3.1 quay.io/prometheus/prometheus:v2.3.1 &
 docker pull ccr.ccs.tencentyun.com/cube-studio/kubesigs-kube-batch:v0.5 && docker tag ccr.ccs.tencentyun.com/cube-studio/kubesigs-kube-batch:v0.5 kubesigs/kube-batch:v0.5 &
 docker pull ccr.ccs.tencentyun.com/cube-studio/quay.io-prometheus-node-exporter:v0.15.2 && docker tag ccr.ccs.tencentyun.com/cube-studio/quay.io-prometheus-node-exporter:v0.15.2 quay.io/prometheus/node-exporter:v0.15.2 &
-docker pull ccr.ccs.tencentyun.com/cube-studio/grafana-grafana:7.5.2 && docker tag ccr.ccs.tencentyun.com/cube-studio/grafana-grafana:7.5.2 grafana/grafana:7.5.2 &
+docker pull ccr.ccs.tencentyun.com/cube-studio/grafana-grafana:9.1.5 && docker tag ccr.ccs.tencentyun.com/cube-studio/grafana-grafana:9.1.5 grafana/grafana:9.1.5 &
 docker pull ccr.ccs.tencentyun.com/cube-studio/kubeflow:training-operator && docker tag ccr.ccs.tencentyun.com/cube-studio/kubeflow:training-operator ccr.ccs.tencentyun.com/cube-studio/kubeflow:training-operator &
 docker pull ccr.ccs.tencentyun.com/cube-studio/metacontroller-metacontroller:v0.3.0 && docker tag ccr.ccs.tencentyun.com/cube-studio/metacontroller-metacontroller:v0.3.0 metacontroller/metacontroller:v0.3.0 &
 docker pull ccr.ccs.tencentyun.com/cube-studio/gcr.io-ml-pipeline-workflow-controller:v2.12.9-license-compliance && docker tag ccr.ccs.tencentyun.com/cube-studio/gcr.io-ml-pipeline-workflow-controller:v2.12.9-license-compliance gcr.io/ml-pipeline/workflow-controller:v2.12.9-license-compliance &


### PR DESCRIPTION
### 问题：在对接kubesphere的Prometheus:v2.32.0时，grafana的部分panel无法正常显示
- 原因：系不同版本的Prometheus在使用同样的promsql查询时，查出的结果集格式不同，导致部分数据无法被grafana正确解析在panel上，将grafana的镜像版本改成9.1.5即可解决问题